### PR TITLE
Update to 1.18.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Official GitHub Repository for the Fabric Minecraft mod [Midas Hunger](https://www.curseforge.com/minecraft/mc-mods/midas-hunger-fabric).
 
-Available languages:\
-:es: Spanish\
-:us: English\
+Available languages:  
+:es: Spanish  
+:us: English  
 :cn: 中文(简体) - by lechiny

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/use
-minecraft_version=1.18.1
-yarn_mappings=1.18.1+build.17
-loader_version=0.12.12
+minecraft_version=1.18.2
+yarn_mappings=1.18.2+build.1
+loader_version=0.13.3
 
 # Mod Properties
 mod_version=2.0.0+1.18.1
@@ -13,4 +13,4 @@ maven_group=accieo.midas.hunger
 archives_base_name=midas-hunger
 
 # Dependencies
-fabric_version=0.45.1+1.18
+fabric_version=0.47.8+1.18.2

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,7 +29,7 @@
     "midashunger.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.11.3",
+    "fabricloader": ">=0.13.3",
     "fabric": "*",
     "minecraft": "1.18.x",
     "java": ">=17"


### PR DESCRIPTION
Nothing changed except the version ids.
The commit message misses the bump fabric launcher info.

Villagers are not guranteed to work, but it looks good.﻿
